### PR TITLE
Update sddm-greeter options.

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -15,6 +15,6 @@ SDDM is a Login Manager for Linux which can be themed by qml. This theme use the
 
 ## Note
 
-You should run the command below before install to test if all dependents was installed
+You should run the command below before install to test if all dependents were installed
 
-- `sddm-greeter --test-mode --theme /usr/share/sddm/themes/deepin/`
+- `sddm-greeter --test-mode --theme deepin/`

--- a/README.MD
+++ b/README.MD
@@ -17,4 +17,4 @@ SDDM is a Login Manager for Linux which can be themed by qml. This theme use the
 
 You should run the command below before install to test if all dependents was installed
 
-- `sddm-greeter --test --theme deepin/`
+- `sddm-greeter --test-mode --theme /usr/share/sddm/themes/deepin/`


### PR DESCRIPTION
According to `man sddm-greeter` the `--theme` option should be used with full path. And the option `--test` was replaced by `--test-mode`.